### PR TITLE
Move loop values to item() and index()

### DIFF
--- a/src/custom-prop.js
+++ b/src/custom-prop.js
@@ -12,10 +12,19 @@ export function pascalCase(propertyName) {
 }
 
 /**
+ * Creates a key for dataset for looking up a key
+ * @param {string} keyName
+ * @returns {string}
+ */
+ export function datasetKey(propertyName) {
+  return 'dsl' + pascalCase(propertyName);
+}
+
+/**
  * Creates a key for dataset for looking up custom properties
  * @param {string} propertyName 
  * @returns {string}
  */
-export function datasetKey(propertyName) {
+export function datasetPropKey(propertyName) {
   return 'dslProp' + pascalCase(propertyName);
 }

--- a/src/dsl.js
+++ b/src/dsl.js
@@ -20,7 +20,9 @@ import {
   AnyValue,
   BindValue,
   GetValue,
+  IndexValue,
   InsertionValue,
+  ItemValue,
   SelectValue,
   VarValue
 } from './value.js';
@@ -37,7 +39,9 @@ const fnMap = new Map([
   ['var', VarValue],
   ['get', GetValue],
   ['select', SelectValue],
-  ['bind', BindValue]
+  ['bind', BindValue],
+  ['index', IndexValue],
+  ['item', ItemValue]
 ]);
 
 /**
@@ -127,7 +131,7 @@ function compile(strings, values) {
             break;
           }
           case 'each': {
-            expectValues(propName, 3);
+            expectValues(propName, 2);
             let ptr = readFirstValuePointer();
             let args = [];
             while(ptr) {
@@ -136,7 +140,6 @@ function compile(strings, values) {
             }
             rule.addDeclaration(new Declaration(rule, 'each-items', args[0]));
             rule.addDeclaration(new Declaration(rule, 'each-template', args[1]));
-            rule.addDeclaration(new Declaration(rule, 'each-scope', args[2]));
             break;
           }
           case 'event':

--- a/src/each.js
+++ b/src/each.js
@@ -14,20 +14,14 @@ export class EachInstance {
    * @param {Element} host 
    * @param {HTMLTemplateElement} template
    * @param {string} key
-   * @param {string} scopeName
-   * @param {string} indexName
    */
-  constructor(host, template, key, scopeName, indexName) {
+  constructor(host, template, key) {
     /** @type {Element} */
     this.host = host;
     /** @type {HTMLTemplateElement} */
     this.template = template;
     /** @type {string} */
     this.key = key;
-    /** @type {string} */
-    this.scopeName = scopeName;
-    /** @type {string} */
-    this.indexName = indexName;
     /** @type {(item: any, index: number) => any} */
     this.keyFn = null;
   }
@@ -60,16 +54,16 @@ export class EachInstance {
    * @param {*} index 
    */
   setData(frag, value, index) {
-    let scopeProp = datasetKey(this.scopeName);
-    let indexProp = datasetKey(this.indexName);
+    let itemProp = datasetKey('Item');
+    let indexProp = datasetKey('Index');
     for(let element of frag.nodes) {
       if('dataset' in element) {
         /** @type {HTMLElement} */
-        (element).dataset[scopeProp] = '';
-        element[Symbol.for(this.scopeName)] = value;
+        (element).dataset[itemProp] = '';
+        element[Symbol.for(itemProp)] = value;
          /** @type {HTMLElement} */
         (element).dataset[indexProp] = '';
-        element[Symbol.for(this.indexName)] = index;
+        element[Symbol.for(indexProp)] = index;
       }
 
     }

--- a/src/render.js
+++ b/src/render.js
@@ -3,7 +3,7 @@
 import { flags } from './bindings.js';
 import { EachInstance } from './each.js';
 import { NO_VALUE } from './compute.js';
-import { datasetKey } from './custom-prop.js';
+import { datasetPropKey } from './custom-prop.js';
 
 /**
  * @typedef {import('./bindings').Bindings} Bindings
@@ -28,7 +28,7 @@ function render(element, bindings, values) {
         if(!(element instanceof HTMLElement)) {
           throw new Error('Custom properties cannot be used on non-HTML elements.');
         }
-        element.dataset[datasetKey(propertyName)] = '';
+        element.dataset[datasetPropKey(propertyName)] = '';
         element[Symbol.for(propertyName)] = compute.get();
       }
     }
@@ -55,14 +55,10 @@ function render(element, bindings, values) {
     /** @type {HTMLTemplateElement} */
     let template = bindings.eachTemplate.compute(values);
     /** @type {string} */
-    let scope = bindings.flags & flags.eachScope ? bindings.eachScope.compute(values) : '--scope';
-    /** @type {string} */
-    let indexVar = bindings.flags & flags.eachIndex ? bindings.eachIndex.compute(values) : '--index';
-    /** @type {string} */
     let key = bindings.flags & flags.eachKey ? bindings.eachKey.compute(values) : '';
     
-    if(!inst || inst.template !== template || inst.scopeName !== scope) {
-      inst = new EachInstance(element, template, key, scope, indexVar);
+    if(!inst || inst.template !== template) {
+      inst = new EachInstance(element, template, key);
       eachInstances.set(element, inst);
     }
     return inst.set(items);

--- a/test/test-each.js
+++ b/test/test-each.js
@@ -9,7 +9,11 @@ QUnit.test('Shorthand each syntax', assert => {
   let todos = [{label: 'walk the dog'}, {label: 'clean the dishes'}];
   let sheet = dsl`
     ul {
-      each: ${todos} select(#todos-template) --todo;
+      each: ${todos} select(#todos-template);
+    }
+
+    li {
+      --todo: item();
     }
 
     .label {
@@ -32,11 +36,10 @@ QUnit.test('Longhand syntax', assert => {
     ul {
       each-items: ${todos};
       each-template: select(#todos-template);
-      each-scope: --todo;
     }
 
     .label {
-      text: get(var(--todo), label);
+      text: get(item(), label);
     }
   `;
   sheet.update(root);
@@ -46,7 +49,7 @@ QUnit.test('Longhand syntax', assert => {
   assert.equal(ul.querySelector(':nth-child(2) span').textContent, 'clean the dishes');
 });
 
-QUnit.test('The index is available as a var', assert => {
+QUnit.test('The index is available as index()', assert => {
   let root = document.createElement('main');
   root.innerHTML = `<ul></ul><template id="todos-template"><li></li></template>`;
 
@@ -55,11 +58,10 @@ QUnit.test('The index is available as a var', assert => {
     ul {
       each-items: ${items};
       each-template: select(#todos-template);
-      each-scope: --todo;
     }
 
     li {
-      data: index var(--index);
+      data: index index();
     }
   `;
   sheet.update(root);
@@ -82,7 +84,7 @@ QUnit.test('Deleting an item in a keyed list updates sibling indices', assert =>
         attr: id get(${item => `item-${item.id}`});
       }
       li #index {
-        text: var(--index);
+        text: index();
       }
     `;
   }

--- a/test/test-get.js
+++ b/test/test-get.js
@@ -56,13 +56,15 @@ QUnit.test('can take a function as the second arg', assert => {
   assert.equal(root.firstElementChild.textContent, 'Hello Wilbur');
 });
 
-QUnit.test('if one arg, implicitly uses --scope as the context', assert => {
+QUnit.test('if one arg, use item() as the context', assert => {
   let root = document.createElement('main');
-  root.innerHTML = `<div id="app">Hello <span id="name"></span></div>`;
+  root.innerHTML = `<div id="app"></div><template>Hello <span id="name"></span></template>`;
   let pet = { name: 'Wilbur' };
   let sheet = dsl`
+    #app {
+      each: ${[pet]} select(template);
+    }
     #name {
-      --scope: ${pet};
       text: get(name);
     }
   `;


### PR DESCRIPTION
This removes the `--scope` and `--index` values we were setting and
replaces with 2 functions `item()` to get the item and `index()` to get
the index. Example usage:

```js
dsl`
  #todos {
    each-items: ${todos};
    each-template: select(#todo-template);
  }

  .todo {
    text: get(item(), label);
  }

  .todo .delete {
    event: click bind(${deleteTodo}, index());
  }
`;
```